### PR TITLE
Add fix to pre-check for consent button

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,9 @@ const generateGPX = function (stage) {
 /* THE MACHINE */
 
 async function scrapePage (url) {
-  const browser = await puppeteer.launch({ headless: 'new' });
+  const browser = await puppeteer.launch({
+    headless: 'new'
+  });
   const page = await browser.newPage();
 
   await page.setViewport({ width: 1080, height: 1024 });
@@ -82,6 +84,17 @@ async function scrapePage (url) {
 
   // cc.acceptCategory('all');
 
+  try {
+    // Wait up to 5 seconds for the selector to appear
+    await page.waitForSelector('.fc-cta-consent', { timeout: 5000 });
+
+    // If it appears, click it
+    await page.click('.fc-cta-consent');
+    console.log('Clicked consent button');
+  } catch (e) {
+    // If the selector doesn't appear, skip it
+    console.log('Consent button not found, moving on');
+  }
   await page.waitForSelector('.cm__body');
   await page.click('.cm__btn >>> ::-p-text(Accept All)');
 


### PR DESCRIPTION
A consent window opens up and prevents the map from loading until it is accepted. This checks for it, if it appears it clicks it. 